### PR TITLE
Shopping API Add IAF token

### DIFF
--- a/src/Shopping/Services/ShoppingBaseService.php
+++ b/src/Shopping/Services/ShoppingBaseService.php
@@ -15,11 +15,11 @@ class ShoppingBaseService extends \DTS\eBaySDK\Services\BaseService
      * HTTP header constant. The API version your application supports.
      */
     const HDR_API_VERSION = 'X-EBAY-API-VERSION';
-
+    
     /**
-     * HTTP header constant. Your application ID.
+     * HTTP header constant. The OAUTH Authentication Token that is used to validate the caller has permission to access the eBay servers.
      */
-    const HDR_APP_ID = 'X-EBAY-API-APP-ID';
+    const HDR_AUTHORIZATION = 'X-EBAY-API-IAF-TOKEN';
 
     /**
      * HTTP header constant. The name of the operation you are calling.
@@ -97,7 +97,7 @@ class ShoppingBaseService extends \DTS\eBaySDK\Services\BaseService
 
         // Add required headers first.
         $headers[self::HDR_API_VERSION] = $this->getConfig('apiVersion');
-        $headers[self::HDR_APP_ID] = $this->getConfig('credentials')->getAppId();
+        $headers[self::HDR_AUTHORIZATION] = $this->getConfig('authorization');
         $headers[self::HDR_OPERATION_NAME] = $operationName;
         $headers[self::HDR_REQUEST_FORMAT] = 'XML';
 


### PR DESCRIPTION
Starting on July 1, 2021, developers using Shopping API calls must authenticate with an OAuth application access token using the X-EBAY-API-IAF-TOKEN HTTP header, as both the appid query parameter and X-EBAY-API-APP-ID HTTP header will be deprecated on June 30, 2021.